### PR TITLE
[Github Action] Generate dist automatically

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,0 +1,37 @@
+name: Generate dist files
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout master
+        uses: actions/checkout@v2
+        with:
+          ref: master
+
+      # https://github.com/actions/setup-node
+      - name: Setup node
+        uses: actions/setup-node@v1
+
+      - name: Generate dist
+        run: make install dist
+
+      - name: Git status
+        run: git status
+
+      # https://github.com/EndBug/add-and-commit
+      - name: Commit & push changes
+        uses: EndBug/add-and-commit@v4
+        with:
+          author_name: GitHub Actions Bot
+          author_email: actions@github.com
+          message: '[AUTO] By Github Actions: generate dist files'
+          add: "docs/"
+          ref: master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Ex dans cette PR qui provoque un changement dans le build: `make dist` automatiquement lancé et commit par les Github Actions (dernier commit).
Le but étant qu'au merge d'une PR, le dossier docs soit automatiquement mis à jour.

**(avant de merger, supprimer le second et dernier commit)**