### PR TITLE
Tom select

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ lint@integration:
 publish: build
 	npm publish . --access public
 
+# Publish package
+publish@beta: build
+	npm publish . --access public --tag beta
+
 ########
 # Demo #
 ########

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ $screen-sm: 750px;
 $screen-md: 1000px;
 ```
 
+### Features
+
+- [Choices dropdown](doc/choices.md)
+
 ## Contributing
 
 ### To the library

--- a/demo/assets/js/app.js
+++ b/demo/assets/js/app.js
@@ -1,7 +1,7 @@
-import '../styles/app.scss';
-
-import { Collapsible, Drop, Tree, MobileSidebar, NavigableTable } from '@elao/admin';
+import TomSelect from 'tom-select';
+import { Collapsible, Drop, Tree, MobileSidebar, NavigableTable, Choice } from '@elao/admin';
 import ColorPicker from './ColorPicker';
+import '../styles/app.scss';
 
 window.addEventListener('load', function onLoad() {
     // Behaviors
@@ -9,6 +9,7 @@ window.addEventListener('load', function onLoad() {
     Drop.init();
     Tree.init();
     NavigableTable.init();
+    Choice.init(TomSelect);
 
     // Mobile
     MobileSidebar.init();

--- a/demo/assets/styles/app.scss
+++ b/demo/assets/styles/app.scss
@@ -1,9 +1,7 @@
+@import "~tom-select/src/scss/tom-select";
 @import '@elao/admin';
 
 @import url('https://fonts.googleapis.com/css2?family=Work+Sans:wght@300;400;600&display=swap');
-
-// Vendors
-//@import "~tom-select/src/scss/tom-select";
 
 // Demo styles only
 @import 'base/variables';

--- a/demo/assets/styles/app.scss
+++ b/demo/assets/styles/app.scss
@@ -2,6 +2,9 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Work+Sans:wght@300;400;600&display=swap');
 
+// Vendors
+//@import "~tom-select/src/scss/tom-select";
+
 // Demo styles only
 @import 'base/variables';
 @import 'base/layout';

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -25480,6 +25480,11 @@
                 }
             }
         },
+        "@orchidjs/sifter": {
+            "version": "0.7.5",
+            "resolved": "https://registry.npmjs.org/@orchidjs/sifter/-/sifter-0.7.5.tgz",
+            "integrity": "sha512-Now0sJCIv/PC0RHpWRvKkr/n0vn7sMs7S+Dq58hv2PWSfCNu6d6SufAWDo04C6w9EX43xp7o43W1fxdFPqG+ng=="
+        },
         "@symfony/webpack-encore": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@symfony/webpack-encore/-/webpack-encore-1.5.0.tgz",
@@ -31289,6 +31294,14 @@
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
             "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
             "dev": true
+        },
+        "tom-select": {
+            "version": "2.0.0-Beta.2",
+            "resolved": "https://registry.npmjs.org/tom-select/-/tom-select-2.0.0-Beta.2.tgz",
+            "integrity": "sha512-jFhhcrfCri7EJ3cUq2EggVeYLbE57pnvEFsVAbrmxUkwcricjhdGRc37mAAgrnVdpW0OYU7hSNnT20e0sOMvXw==",
+            "requires": {
+                "@orchidjs/sifter": "^0.7.5"
+            }
         },
         "tough-cookie": {
             "version": "2.5.0",

--- a/demo/package.json
+++ b/demo/package.json
@@ -11,7 +11,8 @@
         "npm": ">=7"
     },
     "dependencies": {
-        "@elao/admin": "file:../"
+        "@elao/admin": "file:../",
+        "tom-select": "^2.0.0-Beta.2"
     },
     "devDependencies": {
         "@symfony/webpack-encore": "^1.5.0",

--- a/demo/src/Form/UserType.php
+++ b/demo/src/Form/UserType.php
@@ -25,6 +25,14 @@ class UserType extends AbstractType
                 'label' => 'user.premiumUntil',
             ])
             ->add('enabled', CheckboxType::class, ['label' => 'user.enabled'])
+            ->add('country', ChoiceType::class, [
+                'choices'  => [
+                    'France' => 'fr',
+                    'Other' => 'other',
+                ],
+                'label' => 'user.country',
+                'mapped' => false,
+            ])
             ->add('role', ChoiceType::class, [
                 'choices'  => [
                     'role.ROLE_USER' => 'ROLE_USER',
@@ -32,6 +40,22 @@ class UserType extends AbstractType
                     'role.ROLE_ADMIN' => 'ROLE_ADMIN',
                 ],
                 'label' => 'user.role',
+                'attr' => [
+                    'data-choice' => true
+                ],
+            ])
+            ->add('role2', ChoiceType::class, [
+                'choices'  => [
+                    'role.ROLE_USER' => 'ROLE_USER',
+                    'role.ROLE_STAFF' => 'ROLE_STAFF',
+                    'role.ROLE_ADMIN' => 'ROLE_ADMIN',
+                ],
+                'label' => 'user.role',
+                'multiple' => true,
+                'attr' => [
+                    'data-choice' => true
+                ],
+                'mapped' => false,
             ])
             ->add('save', SubmitType::class, ['label' => 'form.save'])
         ;

--- a/demo/translations/messages.fr.yaml
+++ b/demo/translations/messages.fr.yaml
@@ -7,6 +7,7 @@ user:
   name: Nom complet
   email: Adresse email
   role: Rôle
+  country: Pays
   premiumUntil: Premium jusqu'au
   status: Statut
   enabled: Actif

--- a/doc/choices.md
+++ b/doc/choices.md
@@ -2,7 +2,21 @@
 
 ## Installation
 
-In your app.js:
+Require tom-select in your project:
+
+```shell
+npm i tom-select
+```
+
+Include tom-select template in your `app.scss`:
+
+```scss
+@import "~tom-select/src/scss/tom-select";  // Must be imported before "@elao-admin"
+@import '@elao/admin';
+
+```
+
+Àctivate choice plugin in your `app.js` by passing the TomSelect library:
 
 ```javascript
 import TomSelect from 'tom-select';

--- a/doc/choices.md
+++ b/doc/choices.md
@@ -1,0 +1,35 @@
+# Choices dropdown
+
+## Installation
+
+In your app.js:
+
+```javascript
+import TomSelect from 'tom-select';
+import { Choice } from '@elao/admin';
+
+Choice.init(TomSelect);
+```
+
+## Usage
+
+Set the `data-choice` attribute on the select elements you want to activate:
+
+In HTML:
+
+```html
+<select data-choice>
+    <!-- Options... -->
+</select>
+```
+
+Or in Symfony:
+
+```php
+->add('role', ChoiceType::class, [
+    'choices'  => $roles,
+    'attr' => [
+        'data-choice' => true
+    ],
+])
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8960,11 +8960,6 @@
         "fastq": "^1.6.0"
       }
     },
-    "@orchidjs/sifter": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@orchidjs/sifter/-/sifter-0.7.5.tgz",
-      "integrity": "sha512-Now0sJCIv/PC0RHpWRvKkr/n0vn7sMs7S+Dq58hv2PWSfCNu6d6SufAWDo04C6w9EX43xp7o43W1fxdFPqG+ng=="
-    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -13200,14 +13195,6 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
-      }
-    },
-    "tom-select": {
-      "version": "2.0.0-Beta.2",
-      "resolved": "https://registry.npmjs.org/tom-select/-/tom-select-2.0.0-Beta.2.tgz",
-      "integrity": "sha512-jFhhcrfCri7EJ3cUq2EggVeYLbE57pnvEFsVAbrmxUkwcricjhdGRc37mAAgrnVdpW0OYU7hSNnT20e0sOMvXw==",
-      "requires": {
-        "@orchidjs/sifter": "^0.7.5"
       }
     },
     "tough-cookie": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elao/admin",
-  "version": "0.1.6",
+  "version": "0.1.7-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elao/admin",
-      "version": "0.1.6",
+      "version": "0.1.7-beta.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.14.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elao/admin",
-  "version": "0.1.7-beta.0",
+  "version": "0.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elao/admin",
-      "version": "0.1.7-beta.0",
+      "version": "0.1.7",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.14.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8960,6 +8960,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@orchidjs/sifter": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@orchidjs/sifter/-/sifter-0.7.5.tgz",
+      "integrity": "sha512-Now0sJCIv/PC0RHpWRvKkr/n0vn7sMs7S+Dq58hv2PWSfCNu6d6SufAWDo04C6w9EX43xp7o43W1fxdFPqG+ng=="
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -13195,6 +13200,14 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "tom-select": {
+      "version": "2.0.0-Beta.2",
+      "resolved": "https://registry.npmjs.org/tom-select/-/tom-select-2.0.0-Beta.2.tgz",
+      "integrity": "sha512-jFhhcrfCri7EJ3cUq2EggVeYLbE57pnvEFsVAbrmxUkwcricjhdGRc37mAAgrnVdpW0OYU7hSNnT20e0sOMvXw==",
+      "requires": {
+        "@orchidjs/sifter": "^0.7.5"
       }
     },
     "tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elao/admin",
-  "version": "0.1.6",
+  "version": "0.1.7-beta.0",
   "description": "Administration theme",
   "scripts": {
     "watch": "webpack --mode=development --watch",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,5 @@
     "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2"
   },
-  "dependencies": {
-    "tom-select": "^2.0.0-Beta.2"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elao/admin",
-  "version": "0.1.7-beta.0",
+  "version": "0.1.7",
   "description": "Administration theme",
   "scripts": {
     "watch": "webpack --mode=development --watch",

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "style-loader": "^1.3.0",
     "webpack": "^5.40.0",
     "webpack-cli": "^4.7.2"
+  },
+  "dependencies": {
+    "tom-select": "^2.0.0-Beta.2"
   }
 }

--- a/src/behavior/Choice.js
+++ b/src/behavior/Choice.js
@@ -12,7 +12,6 @@ export default class Choice {
         return Array.from(elements).map(element => {
             const config = {
                 create: false,
-                //hideSelected: true,
                 allowEmptyOption: !element.hasAttribute('required'),
                 plugins: []
             };

--- a/src/behavior/Choice.js
+++ b/src/behavior/Choice.js
@@ -10,11 +10,19 @@ export default class Choice {
         const elements = document.body.querySelectorAll('[data-choice]');
 
         return Array.from(elements).map(element => {
-            const config = { create: false, plugins: [] };
+            const config = {
+                create: false,
+                //hideSelected: true,
+                allowEmptyOption: !element.hasAttribute('required'),
+                plugins: []
+            };
 
-            if (element.getAttribute('multiple') === 'multiple') {
+            if (element.hasAttribute('multiple')) {
                 config.plugins.push('remove_button');
                 config.remove_button = { title: 'Remove' };
+            } else {
+                config.maxItems = 1;
+                config.closeAfterSelect = true;
             }
 
             new this(TomSelect, element, config);
@@ -22,6 +30,10 @@ export default class Choice {
     }
 
     constructor(TomSelect, element, config) {
-        this.element = new TomSelect(element, config);
+        this.select = new TomSelect(element, config);
+
+        if (config.closeAfterSelect) {
+            this.select.on('item_add', () => this.select.blur());
+        }
     }
 }

--- a/src/behavior/Choice.js
+++ b/src/behavior/Choice.js
@@ -1,0 +1,27 @@
+/**
+ * Choice
+ */
+export default class Choice {
+    static init(TomSelect) {
+        if (typeof TomSelect === 'undefined') {
+            return console.error('You must pass and instance of tom-select');
+        }
+
+        const elements = document.body.querySelectorAll('[data-choice]');
+
+        return Array.from(elements).map(element => {
+            const config = { create: false, plugins: [] };
+
+            if (element.getAttribute('multiple') === 'multiple') {
+                config.plugins.push('remove_button');
+                config.remove_button = { title: 'Remove' };
+            }
+
+            new this(TomSelect, element, config);
+        });
+    }
+
+    constructor(TomSelect, element, config) {
+        this.element = new TomSelect(element, config);
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import Collapsible from './behavior/Collapsible';
 import Drop from './behavior/Drop';
 import Tree from './behavior/Tree';
 import NavigableTable from './behavior/NavigableTable';
+import Choice from './behavior/Choice';
 import MobileSidebar from './mobile/MobileSidebar';
 
 export {
@@ -11,4 +12,5 @@ export {
     Tree,
     MobileSidebar,
     NavigableTable,
+    Choice,
 };

--- a/style/plugin/tom-select.scss
+++ b/style/plugin/tom-select.scss
@@ -1,35 +1,20 @@
-//$select-font-family: 'Work Sans';
-$select-font-size: 15px;
-$select-line-height: normal;
-
-$select-color-text: #73748F;
-$select-color-border: #edeefa;
-$select-color-highlight: #e2e4f7;
-$select-color-dropdown-item-active: #fafaff;
-$select-color-item-active: #d2d4f2;
-$select-color-item-active-text: #676881;
-$select-color-item: #fafaff;
-$select-color-item-text: #676881;
-$select-color-item-border: #fafaff;
-
-@mixin selectize-vertical-gradient($color-top, $color-bottom) {
-    background-color: mix($color-top, $color-bottom, 60%);
-    background-image: linear-gradient(to bottom, $color-top, $color-bottom);
-    background-repeat: repeat-x;
+.ts-dropdown,
+.ts-control,
+.ts-control input {
+  color: var(--text);
+  font-family: var(--primary-font);
+  font-size: 15px;
 }
-
-@import "~tom-select/src/scss/tom-select";
 
 .ts-wrapper {
   @extend .select;
   overflow: visible;
 
-  //border-color: var(--border);
-
   &::before {
     z-index: 2;
     background: none;
     box-shadow: none;
+    transition: transform 200ms ease-in-out;
   }
 
   &.input-active {
@@ -40,15 +25,14 @@ $select-color-item-border: #fafaff;
     align-items: center;
   }
 
-  .ts-control {
-    display: flex;
-    align-items: center;
-    padding: 0 10px;
-    border-radius: 4px;
-    border: none;
+  &.dropdown-active {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-color: var(--border--dark);
+    box-shadow: 0 2px 4px rgba(#000, 10%);
 
-    > input {
-      height: 100%;
+    &::before {
+      transform: rotate(180deg);
     }
   }
 
@@ -58,13 +42,60 @@ $select-color-item-border: #fafaff;
 
   &.multi .ts-control > div {
     margin: 0 3px 0 0;
+    border-radius: 4px;
+    background-color: var(--background);
+    color: var(--text);
+
+    .remove {
+      border-left: none;
+    }
+
+    &.active {
+      background-color: var(--background--dark);
+      color: var(--text--dark);
+    }
+  }
+}
+
+.ts-dropdown {
+  border-radius: 0 0 4px 4px;
+  overflow: hidden;
+  left: -1px;
+  right: -1px;
+  width: auto;
+  margin: 0;
+  box-shadow: 0 2px 4px rgba(#000, 10%);
+
+  .create:hover,
+  .option:hover,
+  .active {
+    background-color: var(--background);
+    color: var(--text--dark);
   }
 
-  .ts-dropdown-content {
-    .option {
-      min-height: 40px;
-      display: flex;
-      align-items: center;
-    }
+  [data-selectable] .highlight {
+    font-weight: bold;
+    //background: var(--background--dark);
+    background-color: transparent;
+  }
+}
+
+.ts-control {
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  border-radius: 4px;
+  border: none;
+
+  > input {
+    height: 100%;
+  }
+}
+
+.ts-dropdown-content {
+  .option {
+    min-height: 40px;
+    display: flex;
+    align-items: center;
   }
 }

--- a/style/plugin/tom-select.scss
+++ b/style/plugin/tom-select.scss
@@ -1,0 +1,70 @@
+//$select-font-family: 'Work Sans';
+$select-font-size: 15px;
+$select-line-height: normal;
+
+$select-color-text: #73748F;
+$select-color-border: #edeefa;
+$select-color-highlight: #e2e4f7;
+$select-color-dropdown-item-active: #fafaff;
+$select-color-item-active: #d2d4f2;
+$select-color-item-active-text: #676881;
+$select-color-item: #fafaff;
+$select-color-item-text: #676881;
+$select-color-item-border: #fafaff;
+
+@mixin selectize-vertical-gradient($color-top, $color-bottom) {
+    background-color: mix($color-top, $color-bottom, 60%);
+    background-image: linear-gradient(to bottom, $color-top, $color-bottom);
+    background-repeat: repeat-x;
+}
+
+@import "~tom-select/src/scss/tom-select";
+
+.ts-wrapper {
+  @extend .select;
+  overflow: visible;
+
+  //border-color: var(--border);
+
+  &::before {
+    z-index: 2;
+    background: none;
+    box-shadow: none;
+  }
+
+  &.input-active {
+    border-color: var(--border--dark);
+  }
+
+  select {
+    align-items: center;
+  }
+
+  .ts-control {
+    display: flex;
+    align-items: center;
+    padding: 0 10px;
+    border-radius: 4px;
+    border: none;
+
+    > input {
+      height: 100%;
+    }
+  }
+
+  &.single.dropdown-active .item {
+    display: none;
+  }
+
+  &.multi .ts-control > div {
+    margin: 0 3px 0 0;
+  }
+
+  .ts-dropdown-content {
+    .option {
+      min-height: 40px;
+      display: flex;
+      align-items: center;
+    }
+  }
+}

--- a/style/plugin/tom-select.scss
+++ b/style/plugin/tom-select.scss
@@ -75,7 +75,6 @@
 
   [data-selectable] .highlight {
     font-weight: bold;
-    //background: var(--background--dark);
     background-color: transparent;
   }
 }

--- a/style/style.scss
+++ b/style/style.scss
@@ -45,3 +45,5 @@
 @import './animations/collapse';
 @import './animations/tree';
 @import './animations/animated-icons';
+
+@import './plugin/tom-select';


### PR DESCRIPTION
Fix #37

Mise en place de [tom-select](https://tom-select.js.org)

- [x] Recherche text dans les option (autocomplete)
- [x] Support des select multiple avec petite croix pour remove
- [x] Totalement optionnel : il est toujours possible d'utiliser le select standard.

### Questions 
- Est-ce qu'on intègre `tom-select` dans le package `elao-admin` ou est-ce qu'on demande à l'utilisateur de l'installer de son coté ?

---

![Capture d’écran 2021-08-04 à 18 11 21](https://user-images.githubusercontent.com/1846873/128216257-b691278a-4d3a-4ff1-ae06-7be7215e209c.png)
![Capture d’écran 2021-08-04 à 18 11 27](https://user-images.githubusercontent.com/1846873/128216266-83297c79-94ac-46a4-9435-7ebda36f3082.png)


