### PR TITLE
Move out base icons from Tailwind components layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elao/admin",
-  "version": "0.1.10",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@elao/admin",
-      "version": "0.1.10",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.14.6",

--- a/style/base/base-icons.scss
+++ b/style/base/base-icons.scss
@@ -1,71 +1,69 @@
-@layer components {
-  // Base admin icons
-  // Manage icon by importing base-icons.json in https://icomoon.io/app/
-  @font-face {
-    font-family: theme('fontFamily.icons');
-    /**
-      The ~ here means that rather than trying to locate a file relative to our current file's location,
-      locate a file relative to our project's node_modules directory instead.
-      Hence, it'll works either when building & using the default Elao Design System styles,
-      or when building with your own config in the end-user project.
-     */
-    src: url('~@elao/admin/assets/fonts/base-icons.eot');
-    src: url('~@elao/admin/assets/fonts/base-icons.eot') format('embedded-opentype'),
-    url('~@elao/admin/assets/fonts/base-icons.ttf') format('truetype'),
-    url('~@elao/admin/assets/fonts/base-icons.woff') format('woff'),
-    url('~@elao/admin/assets/fonts/base-icons.svg') format('svg');
-    font-weight: normal;
-    font-style: normal;
-    font-display: block;
-  }
+// Base admin icons
+// Manage icon by importing base-icons.json in https://icomoon.io/app/
+@font-face {
+  font-family: theme('fontFamily.icons');
+  /**
+    The ~ here means that rather than trying to locate a file relative to our current file's location,
+    locate a file relative to our project's node_modules directory instead.
+    Hence, it'll works either when building & using the default Elao Design System styles,
+    or when building with your own config in the end-user project.
+   */
+  src: url('~@elao/admin/assets/fonts/base-icons.eot');
+  src: url('~@elao/admin/assets/fonts/base-icons.eot') format('embedded-opentype'),
+  url('~@elao/admin/assets/fonts/base-icons.ttf') format('truetype'),
+  url('~@elao/admin/assets/fonts/base-icons.woff') format('woff'),
+  url('~@elao/admin/assets/fonts/base-icons.svg') format('svg');
+  font-weight: normal;
+  font-style: normal;
+  font-display: block;
+}
 
-  .icon {
-    font-family: theme('fontFamily.icons') !important;
-    speak: never;
-    font-style: normal;
-    font-weight: normal;
-    font-variant: normal;
-    text-transform: none;
-    line-height: 1;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
+.icon {
+  font-family: theme('fontFamily.icons') !important;
+  speak: never;
+  font-style: normal;
+  font-weight: normal;
+  font-variant: normal;
+  text-transform: none;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
 
-  $base-icons: (
-    add: '\e90d',
-    arrow-up: '\e906',
-    arrow-down: '\e907',
-    arrow-left: '\e908',
-    arrow-right: '\e909',
-    bell: '\e91c',
-    bullets: '\e90c',
-    calendar: '\e913',
-    check: '\e90b',
-    chevron-up: '\e902',
-    chevron-down: '\e903',
-    chevron-left: '\e904',
-    chevron-right: '\e905',
-    cross: '\e901',
-    delete: '\e90f',
-    document: '\e917',
-    download: '\e91b',
-    duplicate: '\e914',
-    edit: '\e90e',
-    filter: '\e91a',
-    hide: '\e912',
-    link: '\e916',
-    menu: '\e900',
-    reload: '\e919',
-    search: '\e918',
-    send: '\e910',
-    share: '\e915',
-    show: '\e911',
-    user: '\e90a'
-  );
+$base-icons: (
+  add: '\e90d',
+  arrow-up: '\e906',
+  arrow-down: '\e907',
+  arrow-left: '\e908',
+  arrow-right: '\e909',
+  bell: '\e91c',
+  bullets: '\e90c',
+  calendar: '\e913',
+  check: '\e90b',
+  chevron-up: '\e902',
+  chevron-down: '\e903',
+  chevron-left: '\e904',
+  chevron-right: '\e905',
+  cross: '\e901',
+  delete: '\e90f',
+  document: '\e917',
+  download: '\e91b',
+  duplicate: '\e914',
+  edit: '\e90e',
+  filter: '\e91a',
+  hide: '\e912',
+  link: '\e916',
+  menu: '\e900',
+  reload: '\e919',
+  search: '\e918',
+  send: '\e910',
+  share: '\e915',
+  show: '\e911',
+  user: '\e90a'
+);
 
-  @each $icon-name, $icon-character in $base-icons {
-    .icon--#{$icon-name}:before {
-      content: $icon-character;
-    }
+@each $icon-name, $icon-character in $base-icons {
+  .icon--#{$icon-name}:before {
+    content: $icon-character;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -64,7 +64,6 @@ module.exports = {
     component('data-table'),
     component('form', { variants: true }),
     component('footer', { variants: false, elements: false }),
-    component('icon'),
     component('loader', { elements: false }),
     component('menu-button'),
     component('mobile-nav'),


### PR DESCRIPTION
When using it in a React component that would compute the full class name,
one would like to use it in Tailwind's [`safelist`](https://tailwindcss.com/docs/content-configuration#safelisting-classes) config:

```js
  safelist: [
    { pattern: /^icon(-.*)?$/ },
  ],
```

but it shows up a warning in the build output: 

```shell
warn - The safelist pattern `/^icon(-.*)?$/` doesn't match any Tailwind CSS classes.
warn - Fix this pattern or remove it from your `safelist` configuration.
warn - https://tailwindcss.com/docs/content-configuration#safelisting-classes
```

Unfortunately, this is an unexpected bug with no fix : https://github.com/tailwindlabs/tailwindcss/discussions/7406

Instead, let's always include these classes when imported, by removing it from the `@layer components` directive.